### PR TITLE
Fix: Resolve tailwind-scrollbar dependency issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "recharts": "^2.12.7",
         "sonner": "^1.5.0",
         "tailwind-merge": "^2.5.2",
-        "tailwind-scrollbar": "^4.0.0",
+        "tailwind-scrollbar": "^4.0.1",
         "tailwindcss-animate": "^1.0.7",
         "uuid": "^11.0.5",
         "vaul": "^0.9.3",
@@ -7087,9 +7087,9 @@
       }
     },
     "node_modules/tailwind-scrollbar": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tailwind-scrollbar/-/tailwind-scrollbar-4.0.0.tgz",
-      "integrity": "sha512-elqx9m09VHY8gkrMiyimFO09JlS3AyLFXT0eaLaWPi7ImwHlbZj1ce/AxSis2LtR+ewBGEyUV7URNEMcjP1Z2w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/tailwind-scrollbar/-/tailwind-scrollbar-4.0.1.tgz",
+      "integrity": "sha512-j2ZfUI7p8xmSQdlqaCxEb4Mha8ErvWjDVyu2Ke4IstWprQ/6TmIz1GSLE62vsTlXwnMLYhuvbFbIFzaJGOGtMg==",
       "license": "MIT",
       "dependencies": {
         "prism-react-renderer": "^2.4.1"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "recharts": "^2.12.7",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",
-    "tailwind-scrollbar": "^4.0.0",
+    "tailwind-scrollbar": "^4.0.1",
     "tailwindcss-animate": "^1.0.7",
     "uuid": "^11.0.5",
     "vaul": "^0.9.3",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -83,6 +83,6 @@ export default {
   },
   plugins: [
     require("tailwindcss-animate"),
-    require('tailwind-scrollbar'),
+    require('tailwind-scrollbar')({ nocompatible: true }),
   ],
 } satisfies Config;


### PR DESCRIPTION
Addresses a build failure on Netlify due to a dependency conflict between tailwind-scrollbar and tailwindcss. Suggested solutions include using `--force` or `--legacy-peer-deps` during installation.