### PR TITLE
feat: add message page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,6 +56,7 @@ const Costs = lazyWithTimeout(() => import("@/pages/Costs"));
 const Settings = lazyWithTimeout(() => import("@/pages/Settings"));
 const ImprovedDailyReviews = lazyWithTimeout(() => import("@/pages/ImprovedDailyReviews"));
 const CampaignHealth = lazy(() => import("@/pages/CampaignHealth"));
+const Mensagem = lazyWithTimeout(() => import("@/pages/Mensagem"));
 
 function App() {
   return (
@@ -115,6 +116,7 @@ function App() {
           <Route path="/financeiro" element={<Navigate to="/" replace />} />
           
           <Route path="/saude-campanhas" element={<CampaignHealth />} />
+          <Route path="/mensagem" element={<Mensagem />} />
           <Route path="*" element={<NotFound />} />
         </Route>
       </Routes>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,16 +1,16 @@
 
 import { useLocation } from "react-router-dom";
-import { 
-  Users, 
+import {
+  Users,
   DollarSign,
   Home,
-  ListTodo,
   Receipt,
   CreditCard,
   BarChart3,
   Menu,
   ChevronLeft,
-  Activity
+  Activity,
+  Sparkles
 } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import { useEffect, useState } from "react";
@@ -35,23 +35,25 @@ const financialSubMenu: MenuItem[] = [
 
 const adminMenuItems: MenuItem[] = [
   { icon: Home, label: "Início", path: "/" },
-  { 
-    icon: DollarSign, 
-    label: "Financeiro Muran", 
+  {
+    icon: DollarSign,
+    label: "Financeiro Muran",
     path: "/clientes",
     submenu: financialSubMenu
   },
   { icon: Users, label: "Equipe", path: "/equipe" },
   { icon: BarChart3, label: "Revisão Diária", path: "/revisao-diaria-avancada" },
   { icon: Activity, label: "Saúde das Campanhas", path: "/saude-campanhas" },
+  { icon: Sparkles, label: "Mensagem", path: "/mensagem" },
 ];
 
 const regularMenuItems: MenuItem[] = [
   { icon: Home, label: "Início", path: "/" },
   { icon: Users, label: "Equipe", path: "/equipe" },
-  
+
   { icon: BarChart3, label: "Revisão Diária", path: "/revisao-diaria-avancada" },
   { icon: Activity, label: "Saúde das Campanhas", path: "/saude-campanhas" },
+  { icon: Sparkles, label: "Mensagem", path: "/mensagem" },
 ];
 
 export const Sidebar = ({ onMobileItemClick }: SidebarProps) => {

--- a/src/pages/Mensagem.tsx
+++ b/src/pages/Mensagem.tsx
@@ -1,0 +1,25 @@
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Sparkles } from "lucide-react";
+
+const Mensagem = () => {
+  return (
+    <div className="max-w-7xl mx-auto p-4 md:p-6">
+      <Card className="text-center">
+        <CardHeader>
+          <CardTitle className="flex items-center justify-center gap-2">
+            <Sparkles className="h-6 w-6 text-muran-primary" />
+            Mensagem Especial
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-lg text-muted-foreground">
+            Tenha um dia maravilhoso e cheio de conquistas! ✨
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default Mensagem;
+


### PR DESCRIPTION
## Summary
- add Mensagem page showing a special message
- expose the page in sidebar and router

## Testing
- `npm run lint` *(fails: Unexpected any in supabase functions and require() in tailwind.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b30ade1998832bb6fe04bf238d9d20