### PR TITLE
feat: add accounts health overview page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,6 +56,8 @@ const Costs = lazyWithTimeout(() => import("@/pages/Costs"));
 const Settings = lazyWithTimeout(() => import("@/pages/Settings"));
 const ImprovedDailyReviews = lazyWithTimeout(() => import("@/pages/ImprovedDailyReviews"));
 const CampaignHealth = lazy(() => import("@/pages/CampaignHealth"));
+const Mensagem = lazyWithTimeout(() => import("@/pages/Mensagem"));
+const SaudeContasCampanhas = lazyWithTimeout(() => import("@/pages/SaudeContasCampanhas"));
 
 function App() {
   return (
@@ -113,8 +115,10 @@ function App() {
           
           {/* Redirecionamento da rota antiga do financeiro para a página inicial */}
           <Route path="/financeiro" element={<Navigate to="/" replace />} />
-          
+
+          <Route path="/saude" element={<SaudeContasCampanhas />} />
           <Route path="/saude-campanhas" element={<CampaignHealth />} />
+          <Route path="/mensagem" element={<Mensagem />} />
           <Route path="*" element={<NotFound />} />
         </Route>
       </Routes>

--- a/src/components/account-health/AccountCard.tsx
+++ b/src/components/account-health/AccountCard.tsx
@@ -1,0 +1,145 @@
+import React from "react";
+
+export interface AccountStatus {
+  code: number | string;
+  label: string;
+  tone: "ok" | "warn" | "crit" | "info";
+}
+
+export interface AccountSaldo {
+  type: "numeric" | "credit_card" | "unavailable";
+  value?: number;
+  source?: string;
+  percent?: number;
+}
+
+export interface AccountRecarga {
+  date: string;
+  amount: number;
+}
+
+export interface AccountData {
+  id: string | null;
+  status?: AccountStatus;
+  billing_model: "pre" | "pos";
+  saldo?: AccountSaldo;
+  ultima_recarga?: AccountRecarga | null;
+  badges: string[];
+}
+
+interface AccountCardProps {
+  platform: "meta" | "google";
+  account: AccountData;
+}
+
+const pctToClass = (p: number) => {
+  if (p <= 0.25) return "crit";
+  if (p <= 0.5) return "warn";
+  return "ok";
+};
+
+const money = (v: number | undefined) => {
+  return (v ?? 0).toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
+};
+
+export const AccountCard: React.FC<AccountCardProps> = ({ platform, account }) => {
+  const isMeta = platform === "meta";
+  const plabel = isMeta ? "Meta Ads" : "Google Ads";
+  const logoClass = isMeta ? "meta" : "google";
+
+  const tone = account.status?.tone || "info";
+  const statusChip = <span className={`chip ${tone}`}>{account.status?.label || "—"}</span>;
+  const billingChip = (
+    <span className={`chip ${account.billing_model === "pre" ? "ok" : "info"}`}>
+      {account.billing_model === "pre" ? "Pré‑paga" : "Pós‑paga"}
+    </span>
+  );
+
+  let saldoValue: React.ReactNode;
+  let batteryClass = "ok";
+  let batteryPercent = Math.max(0, Math.min(1, account.saldo?.percent ?? 0));
+
+  if (account.saldo?.type === "numeric") {
+    saldoValue = <div className="value">{money(account.saldo.value)}</div>;
+    batteryClass = pctToClass(batteryPercent);
+  } else if (account.saldo?.type === "credit_card") {
+    saldoValue = <div className="value muted">Cartão de crédito</div>;
+    batteryClass = "info";
+    batteryPercent = 0;
+  } else {
+    saldoValue = <div className="value muted">Indisponível</div>;
+    batteryClass = "crit";
+    batteryPercent = 0;
+  }
+
+  let fonte = "—";
+  if (account.saldo?.type === "numeric") {
+    const src = account.saldo?.source || "—";
+    const map: Record<string, string> = {
+      display_string: "display_string",
+      spendcap_minus_spent: "spend_cap − amount_spent",
+      operational: "operacional (recargas − Insights)",
+      budget_remaining: "orçamento restante",
+    };
+    fonte = map[src] || src;
+  } else if (account.saldo?.type === "credit_card") {
+    fonte = "pagamento automático";
+  }
+
+  let lastHtml: React.ReactNode = (
+    <>
+      <span className="label">Última recarga:</span> <span>—</span>
+    </>
+  );
+  if (account.saldo?.type === "numeric" && account.ultima_recarga) {
+    const d = new Date(account.ultima_recarga.date + "T00:00:00");
+    const date = d.toLocaleDateString("pt-BR");
+    lastHtml = (
+      <>
+        <span className="label">Última recarga:</span> <span>{date}</span>
+        <span>— {money(account.ultima_recarga.amount)}</span>
+      </>
+    );
+  }
+
+  const idText = account.id ? (isMeta ? account.id : `CID ${account.id}`) : "—";
+
+  return (
+    <article className={`card card-account ${platform}`}>
+      <header className="head">
+        <div className="left">
+          <span className={`logo ${logoClass}`}></span>
+          <div>
+            <h4 className="name">{plabel}</h4>
+            <div className="accid">{idText}</div>
+          </div>
+        </div>
+        <div className="chips">
+          {statusChip}
+          {billingChip}
+        </div>
+      </header>
+
+      <div className="saldo">
+        <div className="label">Saldo restante</div>
+        {saldoValue}
+        <div className={`battery ${batteryClass}`} title="Indicador de nível de saldo">
+          <span style={{ width: `${batteryPercent * 100}%` }}></span>
+        </div>
+        <div className="hint">Fonte: {fonte}</div>
+      </div>
+
+      <div className="last">{lastHtml}</div>
+
+      <div className="actions">
+        {account.billing_model === "pos" && account.saldo?.type !== "numeric" && (
+          <button className="btn sm">Definir saldo atual</button>
+        )}
+        <button className="btn ghost sm">Histórico</button>
+        <button className="btn ghost sm">Abrir no {isMeta ? "Gerenciador" : "Ads"}</button>
+      </div>
+    </article>
+  );
+};
+
+export default AccountCard;

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,16 +1,16 @@
 
 import { useLocation } from "react-router-dom";
-import { 
-  Users, 
+import {
+  Users,
   DollarSign,
   Home,
-  ListTodo,
   Receipt,
   CreditCard,
   BarChart3,
   Menu,
   ChevronLeft,
-  Activity
+  Activity,
+  Sparkles
 } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import { useEffect, useState } from "react";
@@ -35,23 +35,25 @@ const financialSubMenu: MenuItem[] = [
 
 const adminMenuItems: MenuItem[] = [
   { icon: Home, label: "Início", path: "/" },
-  { 
-    icon: DollarSign, 
-    label: "Financeiro Muran", 
+  {
+    icon: DollarSign,
+    label: "Financeiro Muran",
     path: "/clientes",
     submenu: financialSubMenu
   },
   { icon: Users, label: "Equipe", path: "/equipe" },
   { icon: BarChart3, label: "Revisão Diária", path: "/revisao-diaria-avancada" },
-  { icon: Activity, label: "Saúde das Campanhas", path: "/saude-campanhas" },
+  { icon: Activity, label: "Saúde", path: "/saude" },
+  { icon: Sparkles, label: "Mensagem", path: "/mensagem" },
 ];
 
 const regularMenuItems: MenuItem[] = [
   { icon: Home, label: "Início", path: "/" },
   { icon: Users, label: "Equipe", path: "/equipe" },
-  
+
   { icon: BarChart3, label: "Revisão Diária", path: "/revisao-diaria-avancada" },
-  { icon: Activity, label: "Saúde das Campanhas", path: "/saude-campanhas" },
+  { icon: Activity, label: "Saúde", path: "/saude" },
+  { icon: Sparkles, label: "Mensagem", path: "/mensagem" },
 ];
 
 export const Sidebar = ({ onMobileItemClick }: SidebarProps) => {

--- a/src/pages/Mensagem.tsx
+++ b/src/pages/Mensagem.tsx
@@ -1,0 +1,25 @@
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Sparkles } from "lucide-react";
+
+const Mensagem = () => {
+  return (
+    <div className="max-w-7xl mx-auto p-4 md:p-6">
+      <Card className="text-center">
+        <CardHeader>
+          <CardTitle className="flex items-center justify-center gap-2">
+            <Sparkles className="h-6 w-6 text-muran-primary" />
+            Mensagem Especial
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-lg text-muted-foreground">
+            Tenha um dia maravilhoso e cheio de conquistas! ✨
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default Mensagem;
+

--- a/src/pages/SaudeContasCampanhas.css
+++ b/src/pages/SaudeContasCampanhas.css
@@ -1,0 +1,85 @@
+.health-page {
+  --bg:#f4f6fb; --panel:#ffffff; --line:#e7ecf5; --soft:#fbfdff;
+  --text:#1f2937; --muted:#6b7280; --brand:#ff7a00;
+  --ok:#21b77a; --warn:#f59e0b; --crit:#ef4444; --info:#3b82f6;
+  --ok-soft:#eaf9f2; --warn-soft:#fff7e8; --crit-soft:#ffefef; --info-soft:#eef5ff;
+  --radius:14px; --shadow:0 6px 18px rgba(15,23,42,.06);
+  background:var(--bg);
+  color:var(--text);
+  font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
+  min-height:100vh;
+}
+
+.health-page *{box-sizing:border-box}
+
+.health-page .container{max-width:1220px;margin:28px auto;padding:0 24px}
+
+.health-page header{display:flex;align-items:flex-end;justify-content:space-between;margin-bottom:14px}
+.health-page .title{font-weight:800;font-size:22px}
+.health-page .muted{color:var(--muted);font-size:12px}
+
+.health-page .btn{background:var(--brand);color:white;border:0;border-radius:10px;padding:10px 14px;font-weight:700;cursor:pointer}
+.health-page .btn.ghost{background:transparent;border:1px solid var(--line);color:#111827}
+.health-page .btn.sm{padding:8px 10px;font-size:13px}
+.health-page .btn.icon{display:inline-flex;align-items:center;gap:8px}
+
+/* Tabs */
+.health-page .tabs{display:flex;gap:8px;margin:10px 0 14px}
+.health-page .tab{padding:10px 14px;border-radius:10px;border:1px solid var(--line);background:var(--panel);cursor:pointer;font-weight:700;font-size:14px}
+.health-page .tab.active{box-shadow:var(--shadow)}
+
+/* Summary */
+.health-page .summary{display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin-bottom:10px}
+.health-page .kpi{background:var(--panel);border:1px solid var(--line);border-radius:var(--radius);padding:14px;box-shadow:var(--shadow)}
+.health-page .kpi .label{display:flex;align-items:center;gap:8px;color:var(--muted);font-weight:700}
+.health-page .kpi .v{font-size:24px;font-weight:800;margin-top:6px}
+.health-page .badge{width:22px;height:22px;border-radius:999px;display:inline-grid;place-items:center;color:#fff;font-weight:800}
+.health-page .b-crit{background:var(--crit)} .health-page .b-warn{background:var(--warn)} .health-page .b-ok{background:var(--ok)} .health-page .b-info{background:var(--info)}
+
+/* Toolbar */
+.health-page .toolbar{margin:8px 0 16px;display:flex;gap:10px;flex-wrap:wrap;background:var(--panel);border:1px solid var(--line);border-radius:var(--radius);padding:12px;box-shadow:var(--shadow)}
+.health-page input[type=text], .health-page select{background:#fff;border:1px solid var(--line);color:var(--text);padding:10px 12px;border-radius:10px}
+.health-page .grow{flex:1;min-width:260px}
+
+/* Grid de clientes: 2 cards (Meta|Google) por linha */
+.health-page .clients{display:grid;grid-template-columns:1fr;gap:14px}
+.health-page .row{display:grid;grid-template-columns:1fr 1fr;gap:14px}
+
+/* Card padronizado */
+.health-page .card{background:var(--panel);border:1px solid var(--line);border-radius:var(--radius);padding:14px;box-shadow:var(--shadow);min-height:200px;display:grid;grid-template-rows:auto auto auto auto;gap:10px}
+.health-page .head{display:flex;align-items:center;justify-content:space-between;gap:6px}
+.health-page .left{display:flex;align-items:center;gap:10px;min-width:0}
+.health-page .logo{width:22px;height:22px;border-radius:6px;background:#111;display:inline-block}
+.health-page .logo.meta{background:#4267B2}
+.health-page .logo.google{background:#34A853}
+.health-page .name{font-weight:800;margin:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:340px}
+.health-page .accid{font-size:12px;color:var(--muted)}
+.health-page .chips{display:flex;gap:6px;flex-wrap:wrap;justify-content:flex-end}
+.health-page .chip{padding:4px 8px;border-radius:999px;font-size:11px;font-weight:800;border:1px solid var(--line);background:#f4f6fb;color:#374151}
+.health-page .chip.ok{background:var(--ok-soft);color:#065f46;border-color:#ccf3e1}
+.health-page .chip.warn{background:var(--warn-soft);color:#92400e;border-color:#ffe4b5}
+.health-page .chip.crit{background:var(--crit-soft);color:#991b1b;border-color:#ffd2d2}
+.health-page .chip.info{background:var(--info-soft);color:#1e40af;border-color:#cfe0ff}
+
+/* Saldo */
+.health-page .saldo{display:grid;grid-template-columns:1fr auto;align-items:center;gap:8px}
+.health-page .saldo .label{font-size:12px;color:var(--muted)}
+.health-page .saldo .value{font-size:22px;font-weight:900}
+.health-page .saldo .value.muted{font-weight:700;color:#6b7280}
+.health-page .battery{grid-column:1/-1;height:8px;border:1px solid var(--line);border-radius:999px;background:#f1f5f9;position:relative;overflow:hidden}
+.health-page .battery>span{position:absolute;left:0;top:0;bottom:0;background:linear-gradient(90deg,#21b77a,#74e0b8)}
+.health-page .battery.warn>span{background:linear-gradient(90deg,#ffcc66,#ffe39d)}
+.health-page .battery.crit>span{background:linear-gradient(90deg,#ff6b6b,#ff9d9d)}
+.health-page .hint{grid-column:1/-1;color:var(--muted);font-size:12px}
+
+/* Última recarga (sempre reserva a linha) */
+.health-page .last{display:flex;gap:6px;align-items:center;color:var(--muted);font-size:12px}
+.health-page .last .label{font-weight:700;color:#374151}
+
+/* Rodapé */
+.health-page .actions{display:flex;gap:8px;justify-content:flex-end}
+
+/* Estado "sem conta" mantém altura */
+.health-page .empty{opacity:.75;display:grid;place-items:center;border-style:dashed}
+
+@media (max-width:1024px){.health-page .row{grid-template-columns:1fr}}

--- a/src/pages/SaudeContasCampanhas.tsx
+++ b/src/pages/SaudeContasCampanhas.tsx
@@ -1,0 +1,157 @@
+import React, { useState } from "react";
+import AccountCard, { AccountData } from "@/components/account-health/AccountCard";
+import "./SaudeContasCampanhas.css";
+
+interface ClientData {
+  cliente: string;
+  meta?: AccountData | null;
+  google?: AccountData | null;
+}
+
+const sampleData: ClientData[] = [
+  {
+    cliente: 'Megha Imóveis',
+    meta: {
+      id: 'act_192612319156232',
+      status: { code: 1, label: 'Ativa', tone: 'ok' },
+      billing_model: 'pos',
+      saldo: { type: 'numeric', value: 91.81, source: 'operational', percent: 0.22 },
+      ultima_recarga: { date: '2025-08-01', amount: 900.00 },
+      badges: []
+    },
+    google: {
+      id: '123-456-7890',
+      status: { code: 'ENABLED', label: 'Ativa', tone: 'ok' },
+      billing_model: 'pos',
+      saldo: { type: 'credit_card' },
+      ultima_recarga: null,
+      badges: []
+    }
+  },
+  {
+    cliente: 'Simmons Colchões',
+    meta: {
+      id: 'act_5616617858447105',
+      status: { code: 1, label: 'Ativa', tone: 'ok' },
+      billing_model: 'pre',
+      saldo: { type: 'numeric', value: 310.29, source: 'display_string', percent: 0.68 },
+      ultima_recarga: { date: '2025-08-18', amount: 500.00 },
+      badges: []
+    },
+    google: {
+      id: '234-567-8901',
+      status: { code: 'ENABLED', label: 'Ativa', tone: 'ok' },
+      billing_model: 'pos',
+      saldo: { type: 'credit_card' },
+      ultima_recarga: null,
+      badges: []
+    }
+  },
+  {
+    cliente: 'Elegance Móveis',
+    meta: {
+      id: 'act_23846346246380483',
+      status: { code: 2, label: 'Inativa', tone: 'crit' },
+      billing_model: 'pos',
+      saldo: { type: 'numeric', value: -23.27, source: 'operational', percent: 0 },
+      ultima_recarga: { date: '2025-07-28', amount: 300.00 },
+      badges: ['erro_pagamento']
+    },
+    google: {
+      id: null,
+      status: { code: 'NONE', label: 'Não conectado', tone: 'info' },
+      billing_model: 'pos',
+      saldo: { type: 'unavailable' },
+      ultima_recarga: null,
+      badges: []
+    }
+  },
+  {
+    cliente: 'Astra Design',
+    meta: {
+      id: 'act_1111111111111',
+      status: { code: 1, label: 'Ativa', tone: 'ok' },
+      billing_model: 'pre',
+      saldo: { type: 'numeric', value: 154.10, source: 'display_string', percent: 0.45 },
+      ultima_recarga: { date: '2025-08-20', amount: 200.00 },
+      badges: []
+    },
+    google: {
+      id: '999-222-3333',
+      status: { code: 'ENABLED', label: 'Ativa', tone: 'ok' },
+      billing_model: 'pos',
+      saldo: { type: 'numeric', value: 75.00, source: 'budget_remaining', percent: 0.3 },
+      ultima_recarga: null,
+      badges: []
+    }
+  }
+];
+
+const SaudeContasCampanhas: React.FC = () => {
+  const [activeTab, setActiveTab] = useState<'contas' | 'campanhas'>('contas');
+  const [search, setSearch] = useState('');
+  const [clients, setClients] = useState<ClientData[]>(sampleData);
+
+  const handleSort = () => {
+    const sorted = [...clients].sort((a, b) => {
+      const aVals = [a.meta?.saldo, a.google?.saldo]
+        .filter((s): s is AccountData['saldo'] => !!s && s.type === 'numeric')
+        .map(s => s!.value || 0);
+      const bVals = [b.meta?.saldo, b.google?.saldo]
+        .filter((s): s is AccountData['saldo'] => !!s && s.type === 'numeric')
+        .map(s => s!.value || 0);
+      const aMin = aVals.length ? Math.min(...aVals) : Number.POSITIVE_INFINITY;
+      const bMin = bVals.length ? Math.min(...bVals) : Number.POSITIVE_INFINITY;
+      return aMin - bMin;
+    });
+    setClients(sorted);
+  };
+
+  const filtered = clients.filter(c => c.cliente.toLowerCase().includes(search.toLowerCase()));
+
+  return (
+    <div className="health-page">
+      <div className="container">
+        <header>
+          <div>
+            <div className="title">Saúde – Visão de Contas & Campanhas</div>
+            <div className="muted">Wireframe com cards padronizados (Meta | Google por cliente)</div>
+          </div>
+          <button className="btn icon" onClick={() => { /* placeholder */ }}>⟳ Atualizar</button>
+        </header>
+
+        <div className="tabs">
+          <button className={`tab ${activeTab === 'contas' ? 'active' : ''}`} onClick={() => setActiveTab('contas')}>Visão de Contas</button>
+          <button className={`tab ${activeTab === 'campanhas' ? 'active' : ''}`} onClick={() => setActiveTab('campanhas')}>Visão de Campanhas</button>
+        </div>
+
+        {activeTab === 'contas' ? (
+          <>
+            <div className="toolbar">
+              <input className="grow" type="text" placeholder="Buscar cliente…" value={search} onChange={e => setSearch(e.target.value)} />
+              <select><option value="">Tipo (todos)</option><option value="pre">Pré‑paga</option><option value="pos">Pós‑paga</option></select>
+              <select><option value="">Urgência (todas)</option><option value="crit">Crítico</option><option value="warn">Alto</option><option value="ok">OK</option></select>
+              <button className="btn sm" onClick={handleSort}>Ordenar por menor saldo</button>
+            </div>
+
+            <section className="clients">
+              {filtered.map(client => (
+                <React.Fragment key={client.cliente}>
+                  <div className="muted" style={{ margin: '6px 2px 2px' }}>Cliente: <strong>{client.cliente}</strong></div>
+                  <div className="row">
+                    {client.meta ? <AccountCard platform="meta" account={client.meta} /> : <article className="card empty"><div>Meta · sem conta conectada</div></article>}
+                    {client.google ? <AccountCard platform="google" account={client.google} /> : <article className="card empty"><div>Google · sem conta conectada</div></article>}
+                  </div>
+                </React.Fragment>
+              ))}
+            </section>
+          </>
+        ) : (
+          <div className="muted" style={{ marginTop: '20px' }}>Visão de Campanhas em desenvolvimento…</div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default SaudeContasCampanhas;


### PR DESCRIPTION
## Summary
- add combined accounts & campaigns health page with tabs
- provide reusable account card component matching reference design
- hook new health page into router and sidebar navigation

## Testing
- `npm run lint` *(fails: Unexpected any and require usage in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68b30ade1998832bb6fe04bf238d9d20