### PR TITLE
feat: parse Meta Ads balance display strings

### DIFF
--- a/src/hooks/useMetaBalance.ts
+++ b/src/hooks/useMetaBalance.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
+import { parseMetaBalance } from "@/utils/metaBalance";
 
 export interface ApiAccount {
   id: string | null;
@@ -32,7 +33,36 @@ export const useMetaBalance = (accountId?: string) => {
         console.error("Erro ao buscar saldo Meta:", error);
         throw error;
       }
-      return (data || []) as ApiClient[];
+
+      const clients = (data || []) as any[];
+      return clients.map(client => {
+        const meta = client.meta as any;
+        if (meta) {
+          const balance = parseMetaBalance(
+            meta.balance,
+            meta.spend_cap,
+            meta.amount_spent
+          );
+
+          if (balance !== null) {
+            meta.balance_type = "numeric";
+            meta.balance_value = balance;
+            meta.balance_source = meta.balance
+              ? "display_string"
+              : meta.spend_cap > 0
+              ? "spend_cap_minus_spent"
+              : undefined;
+
+            if (meta.spend_cap && meta.spend_cap > 0) {
+              meta.balance_percent = balance / meta.spend_cap;
+            }
+          } else {
+            meta.balance_type = "unavailable";
+          }
+        }
+
+        return client as ApiClient;
+      });
     },
   });
 };

--- a/src/utils/metaBalance.ts
+++ b/src/utils/metaBalance.ts
@@ -1,0 +1,28 @@
+/**
+ * Extrai o saldo numérico a partir de uma string exibida pela API Meta Ads.
+ * Exemplo de entrada: "Saldo disponível (R$310,29 BRL)".
+ * Se não for possível extrair o valor e houver spendCap, retorna spendCap - amountSpent.
+ * Caso contrário, retorna null indicando saldo indisponível.
+ */
+export const parseMetaBalance = (
+  displayString?: string | null,
+  spendCap?: number | null,
+  amountSpent?: number | null
+): number | null => {
+  if (displayString) {
+    const match = displayString.match(/R\$\s*([\d.,]+)/);
+    if (match && match[1]) {
+      const numeric = parseFloat(match[1].replace(/\./g, "").replace(",", "."));
+      if (!isNaN(numeric)) {
+        return numeric;
+      }
+    }
+  }
+
+  if (spendCap && spendCap > 0) {
+    const spent = amountSpent ?? 0;
+    return spendCap - spent;
+  }
+
+  return null;
+};


### PR DESCRIPTION
## Summary
- add utility to extract Meta Ads balance from display string
- compute Meta balance values in useMetaBalance hook with fallback to spend cap minus spent

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b31d311a50832b95531af8240ae1fb