### PR TITLE
Handle credit-card accounts and last funding event

### DIFF
--- a/src/pages/SaldoCampanhas.tsx
+++ b/src/pages/SaldoCampanhas.tsx
@@ -3,7 +3,7 @@ import { useMetaBalance, ApiClient, ApiAccount } from "@/hooks/useMetaBalance";
 
 interface AccountInfo {
   id: string | null;
-  status?: { code: any; label: string; tone: "ok" | "warn" | "crit" | "info" };
+  status?: { code: unknown; label: string; tone: "ok" | "warn" | "crit" | "info" };
   billing_model?: "pre" | "pos";
   saldo?: {
     type: "numeric" | "credit_card" | "unavailable";
@@ -129,7 +129,7 @@ function Card({ platform, obj }: CardProps) {
       <span className="font-semibold text-gray-600">Última recarga:</span> <span>—</span>
     </>
   );
-  if (obj.saldo?.type === "numeric" && obj.ultima_recarga) {
+  if (obj.ultima_recarga) {
     const d = new Date(obj.ultima_recarga.date + "T00:00:00");
     const date = d.toLocaleDateString("pt-BR");
     lastHtml = (


### PR DESCRIPTION
## Summary
- detect credit card Meta accounts and avoid computing numeric balances
- parse `last_funding_event` to expose last recharge date and amount
- show credit card balance text and display last recharge info in card

## Testing
- `npm run lint` *(fails: Unexpected any in other files)*
- `npx eslint src/hooks/useMetaBalance.ts src/pages/SaldoCampanhas.tsx -f json`


------
https://chatgpt.com/codex/tasks/task_e_68b31e53cfcc832ba243a44de77c4586