### PR TITLE
Add refresh controls to campaign balance page

### DIFF
--- a/src/pages/SaldoCampanhas.tsx
+++ b/src/pages/SaldoCampanhas.tsx
@@ -196,7 +196,7 @@ function Card({ platform, obj }: CardProps) {
 export default function SaldoCampanhas() {
   const [search, setSearch] = useState("");
   const [clients, setClients] = useState<ClientData[]>([]);
-  const { data: apiClients } = useMetaBalance();
+  const { data: apiClients, refetch, isFetching } = useMetaBalance();
 
   useEffect(() => {
     if (apiClients) {
@@ -235,8 +235,12 @@ export default function SaldoCampanhas() {
               Wireframe com cards padronizados (Meta | Google por cliente)
             </div>
           </div>
-          <button className="bg-[#ff7a00] text-white rounded-lg px-3 py-2 font-bold">
-            ⟳ Atualizar
+          <button
+            onClick={() => refetch()}
+            disabled={isFetching}
+            className="bg-[#ff7a00] text-white rounded-lg px-3 py-2 font-bold disabled:opacity-50"
+          >
+            {isFetching ? "Atualizando…" : "⟳ Atualizar"}
           </button>
         </header>
 


### PR DESCRIPTION
## Summary
- enable manual refresh of Meta balance data
- disable and update refresh button label while fetching

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and require import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b321a2a028832b92fdf27770c811ac