### PR TITLE
fix: convert Meta balance values to reais

### DIFF
--- a/src/utils/metaBalance.ts
+++ b/src/utils/metaBalance.ts
@@ -1,13 +1,13 @@
 /**
  * Extrai o saldo numérico a partir de uma string exibida pela API Meta Ads.
  * Exemplo de entrada: "Saldo disponível (R$310,29 BRL)".
- * Se não for possível extrair o valor e houver spendCap, retorna spendCap - amountSpent.
+ * Se não for possível extrair o valor e houver spendCap, retorna (spendCap - amountSpent) / 100.
  * Caso contrário, retorna null indicando saldo indisponível.
  */
 export const parseMetaBalance = (
   displayString?: string | null,
-  spendCap?: number | null,
-  amountSpent?: number | null
+  spendCap?: number | string | null,
+  amountSpent?: number | string | null
 ): number | null => {
   if (displayString) {
     const match = displayString.match(/R\$\s*([\d.,]+)/);
@@ -19,9 +19,12 @@ export const parseMetaBalance = (
     }
   }
 
-  if (spendCap && spendCap > 0) {
-    const spent = amountSpent ?? 0;
-    return spendCap - spent;
+  if (spendCap && Number(spendCap) > 0) {
+    const spent =
+      amountSpent !== undefined && amountSpent !== null
+        ? Number(amountSpent)
+        : 0;
+    return (Number(spendCap) - spent) / 100;
   }
 
   return null;


### PR DESCRIPTION
## Summary
- convert Meta balance calculations from cents to reais
- coerce spendCap and amountSpent inputs to numbers

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unexpected any. Specify a different type @typescript-eslint/no-explicit-any, A `require()` style import is forbidden @typescript-eslint/no-require-imports)


------
https://chatgpt.com/codex/tasks/task_e_68b32382f910832ba4bcf8e7f2f558ee