### PR TITLE
fix: convert Meta balance amounts to reais

### DIFF
--- a/src/utils/metaBalance.ts
+++ b/src/utils/metaBalance.ts
@@ -1,7 +1,8 @@
 /**
  * Extrai o saldo numérico a partir de uma string exibida pela API Meta Ads.
  * Exemplo de entrada: "Saldo disponível (R$310,29 BRL)".
- * Se não for possível extrair o valor e houver spendCap, retorna (spendCap - amountSpent) / 100.
+ * Se não for possível extrair o valor e houver spendCap, retorna spendCap - amountSpent.
+ * Os valores de spendCap e amountSpent devem estar em reais.
  * Caso contrário, retorna null indicando saldo indisponível.
  */
 export const parseMetaBalance = (
@@ -24,7 +25,7 @@ export const parseMetaBalance = (
       amountSpent !== undefined && amountSpent !== null
         ? Number(amountSpent)
         : 0;
-    return (Number(spendCap) - spent) / 100;
+    return Number(spendCap) - spent;
   }
 
   return null;


### PR DESCRIPTION
## Summary
- read spend cap and amount spent in BRL before parsing Meta balance
- parse last recharge amount in reais
- adjust balance parser to handle BRL values directly

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npm run build`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b3241330dc832ba449432285f448ca