### PR TITLE
feat: track meta funding details

### DIFF
--- a/src/components/improved-reviews/hooks/useUnifiedReviewsData.ts
+++ b/src/components/improved-reviews/hooks/useUnifiedReviewsData.ts
@@ -54,7 +54,7 @@ export function useUnifiedReviewsData() {
       // Buscar contas Meta da tabela unificada client_accounts
       const { data: metaAccounts, error: accountsError } = await supabase
         .from("client_accounts")
-        .select("*, last_funding_detected_at")
+        .select("*, last_funding_detected_at, last_funding_amount")
         .eq("status", "active")
         .eq("platform", "meta")
         .order("client_id")
@@ -333,7 +333,8 @@ export function useUnifiedReviewsData() {
                meta_daily_budget: review?.daily_budget_current || 0,
                balance_info: balanceInfo || null,
                veiculationStatus: veiculationStatus,
-               last_funding_detected_at: account.last_funding_detected_at
+               last_funding_detected_at: account.last_funding_detected_at,
+               last_funding_amount: account.last_funding_amount
              };
             
             console.log(`📝 Cliente processado: ${client.company_name} (${account.account_name})`, {

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -290,6 +290,7 @@ export type Database = {
           is_prepay_account: boolean | null
           is_primary: boolean
           last_funding_detected_at: string | null
+          last_funding_amount: number | null
           platform: string
           saldo_restante: number | null
           status: string
@@ -306,6 +307,7 @@ export type Database = {
           is_prepay_account?: boolean | null
           is_primary?: boolean
           last_funding_detected_at?: string | null
+          last_funding_amount?: number | null
           platform: string
           saldo_restante?: number | null
           status?: string
@@ -322,6 +324,7 @@ export type Database = {
           is_prepay_account?: boolean | null
           is_primary?: boolean
           last_funding_detected_at?: string | null
+          last_funding_amount?: number | null
           platform?: string
           saldo_restante?: number | null
           status?: string

--- a/supabase/functions/unified-meta-review/individual.ts
+++ b/supabase/functions/unified-meta-review/individual.ts
@@ -92,7 +92,8 @@ export async function processIndividualReview(request: IndividualReviewRequest) 
     console.log(`✅ [INDIVIDUAL] Informações básicas obtidas (${basicInfoTime}ms):`, {
       accountName: basicAccountInfo.accountName,
       isPrepayAccount: basicAccountInfo.isPrepayAccount,
-      hasFundingRecent: basicAccountInfo.hasFundingRecent
+      lastFundingDate: basicAccountInfo.lastFundingDate,
+      lastFundingAmount: basicAccountInfo.lastFundingAmount
     });
 
     // 6. Buscar dados da Meta API
@@ -160,13 +161,18 @@ export async function processIndividualReview(request: IndividualReviewRequest) 
       updated_at: new Date().toISOString()
     };
 
-    // Se detectou funding recente em conta não pré-paga, atualizar timestamp
-    if (!balanceData.is_prepay_account && basicAccountInfo.hasFundingRecent) {
-      updateData.last_funding_detected_at = new Date().toISOString();
-      console.log(`✅ [DATABASE] FUNDING DETECTADO! Atualizando last_funding_detected_at para conta ${metaAccount.id}`);
+    // Se detectou funding recente em conta não pré-paga, atualizar timestamp e valor
+    if (!balanceData.is_prepay_account && basicAccountInfo.lastFundingDate) {
+      updateData.last_funding_detected_at = basicAccountInfo.lastFundingDate;
+      if (basicAccountInfo.lastFundingAmount !== null) {
+        updateData.last_funding_amount = basicAccountInfo.lastFundingAmount;
+      }
+      console.log(`✅ [DATABASE] FUNDING DETECTADO! Atualizando dados de funding para conta ${metaAccount.id}`);
     } else {
-      console.log(`ℹ️ [DATABASE] Sem funding detectado - is_prepay_account: ${balanceData.is_prepay_account}, hasFundingRecent: ${basicAccountInfo.hasFundingRecent}`);
+      console.log(`ℹ️ [DATABASE] Sem funding detectado - is_prepay_account: ${balanceData.is_prepay_account}, lastFundingDate: ${basicAccountInfo.lastFundingDate}`);
     }
+
+    console.log('📦 [DATABASE] Dados preparados para atualização em client_accounts:', updateData);
 
     const { error: updateAccountError } = await supabase
       .from('client_accounts')

--- a/supabase/migrations/20250908180534_c02f3add-40d0-4036-9a69-1458c909a5e2.sql
+++ b/supabase/migrations/20250908180534_c02f3add-40d0-4036-9a69-1458c909a5e2.sql
@@ -1,0 +1,3 @@
+-- Adicionar campo last_funding_amount para armazenar o valor do último funding detectado (em BRL)
+ALTER TABLE public.client_accounts
+ADD COLUMN last_funding_amount numeric;


### PR DESCRIPTION
## Summary
- capture most recent Meta funding event details
- persist funding timestamp and amount on client accounts
- expose funding data through unified review hooks
- log prepared data for client_accounts updates

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `/root/.deno/bin/deno eval --unsafely-ignore-certificate-errors=esm.sh,socrnutfpqtcjmetskta.supabase.co 'import { processIndividualReview } from "./supabase/functions/unified-meta-review/individual.ts"; const result = await processIndividualReview({clientId:"a9cedcec-2d3f-47c3-b9b1-cf7ded1e8835"}); console.log(JSON.stringify(result));'` *(fails: supabaseUrl is required)*
- `/root/.deno/bin/deno eval --unsafely-ignore-certificate-errors=esm.sh,socrnutfpqtcjmetskta.supabase.co 'import { createClient } from "https://esm.sh/@supabase/supabase-js@2.48.1"; const supabase=createClient(Deno.env.get("SUPABASE_URL")!, Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!); const {data,error}=await supabase.from("client_accounts").select("id,last_funding_detected_at,last_funding_amount").limit(1); console.log(data,error);'` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1a4e482c832bad61f7c2e8d03fb6